### PR TITLE
feat: Redis cache module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "class-transformer": "0.5.1",
         "class-validator": "^0.13.2",
         "google-auth-library": "^8.5.2",
+        "ioredis": "^5.6.0",
         "joi": "^17.6.1",
         "passport": "^0.6.0",
         "passport-google-oauth20": "^2.0.0",
@@ -917,6 +918,12 @@
       "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
       "deprecated": "Use @eslint/object-schema instead",
       "dev": true
+    },
+    "node_modules/@ioredis/commands": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.2.0.tgz",
+      "integrity": "sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg==",
+      "license": "MIT"
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
@@ -3776,6 +3783,15 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -4202,6 +4218,15 @@
       "dev": true,
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/depd": {
@@ -6109,6 +6134,30 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/ioredis": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.6.0.tgz",
+      "integrity": "sha512-tBZlIIWbndeWBWCXWZiqtOF/yxf6yZX3tAlTJ7nfo5jhd6dctNxF7QnYlZLZ1a0o0pDoen7CgZqO+zjNaFbJAg==",
+      "license": "MIT",
+      "dependencies": {
+        "@ioredis/commands": "^1.1.1",
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.4",
+        "denque": "^2.1.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.isarguments": "^3.1.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ioredis"
+      }
+    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -7502,10 +7551,22 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+      "license": "MIT"
+    },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
       "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="
+    },
+    "node_modules/lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
+      "license": "MIT"
     },
     "node_modules/lodash.isboolean": {
       "version": "3.0.3",
@@ -8948,6 +9009,27 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "license": "MIT",
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/reflect-metadata": {
       "version": "0.1.14",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.14.tgz",
@@ -9538,6 +9620,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
+      "license": "MIT"
     },
     "node_modules/statuses": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "class-transformer": "0.5.1",
     "class-validator": "^0.13.2",
     "google-auth-library": "^8.5.2",
+    "ioredis": "^5.6.0",
     "joi": "^17.6.1",
     "passport": "^0.6.0",
     "passport-google-oauth20": "^2.0.0",

--- a/planetary.json
+++ b/planetary.json
@@ -8,6 +8,16 @@
           "description": "Sendgrid implementation of email module"
         }
       ]
+    },
+    "cache": {
+      "path": "src/cache",
+      "implementations": [
+        {
+          "name": "redis",
+          "description": "Redis implementation of cache module",
+          "dependencies": ["ioredis"]
+        }
+      ]
     }
   }
 }

--- a/src/cache/redis/README.md
+++ b/src/cache/redis/README.md
@@ -1,0 +1,176 @@
+# Redis Cache Module
+
+A NestJS module that provides Redis caching functionality with a clean, injectable service interface.
+
+## Overview
+
+This module provides a Redis-based caching solution for NestJS applications. It includes:
+
+- A configurable Redis cache module
+- A service wrapper for Redis operations
+- Mock implementations for testing
+
+## Directory Structure
+
+```
+redis/
+├── README.md
+├── cache.module.ts # Redis cache module configuration
+├── cache.service.ts # Redis cache service implementation
+└── mocks/ # Mock implementations for testing
+```
+
+## Features
+
+- Configurable Redis connection
+- Type-safe cache operations
+- Easy-to-use service interface
+- Testing utilities and mocks
+- Integration with NestJS dependency injection
+
+## Installation
+
+Ensure you have the required dependencies:
+
+```bash
+npm install ioredis
+```
+
+## Usage
+
+### 1. Import the Module
+
+```typescript
+import { Module } from '@nestjs/common';
+import { RedisCacheModule } from './cache/redis/cache.module';
+
+@Module({
+  imports: [
+    RedisCacheModule.forRoot({
+      host: 'localhost',
+      port: 6379,
+      // other Redis options...
+    }),
+  ],
+})
+export class AppModule {}
+```
+
+### 2. Use the Cache Service
+
+```typescript
+import { Injectable } from '@nestjs/common';
+import { RedisCacheService } from './cache/redis/cache.service';
+
+@Injectable()
+export class YourService {
+  constructor(private readonly cacheService: RedisCacheService) {}
+
+  async getData(key: string): Promise<any> {
+    // Try to get from cache first
+    const cached = await this.cacheService.get(key);
+    if (cached) return cached;
+
+    // If not in cache, get data and cache it
+    const data = await this.fetchData();
+    await this.cacheService.set(key, data);
+    return data;
+  }
+}
+```
+
+## Configuration Options
+
+The `RedisCacheModule.forRoot()` method accepts standard Redis configuration options:
+
+```typescript
+interface RedisCacheModuleOptions {
+  protocol: 'redis' | 'rediss';
+  password?: string;
+  host: string;
+  port: number;
+  clusterMode?: boolean;
+  reconnectionDelayMs?: number;
+  reconnectionMaxRetries?: number;
+}
+```
+
+There's also a `forRootAsync` option which allows for dependency injection. For instance, the module can be used in the following fashion:
+
+```typescript
+RedisCacheModule.forRootAsync({
+  useFactory: (config: ConfigType<typeof redisConfig>) => config,
+  inject: [redisConfig.KEY],
+}),
+```
+
+Assuming that a `redisConfig` is registered using `@nestjs/common`'s `registerAs` method.
+
+## API Reference
+
+### RedisCacheService
+
+The main service for interacting with Redis cache:
+
+```typescript
+class RedisCacheService {
+  // Store a value in cache
+  async set(key: string, value: any, ttl?: number): Promise<void>;
+
+  // Retrieve a value from cache
+  async get<T>(key: string): Promise<T | null>;
+}
+```
+
+## Testing
+
+The module includes mock implementations for testing:
+
+```typescript
+import { RedisCacheMockService } from './cache/redis/mocks/cache.mock.service';
+
+describe('YourService', () => {
+  let service: YourService;
+  let cacheService: RedisCacheMockService;
+
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      providers: [
+        YourService,
+        {
+          provide: RedisCacheService,
+          useClass: RedisCacheMockService,
+        },
+      ],
+    }).compile();
+
+    service = module.get(YourService);
+    cacheService = module.get(RedisCacheService);
+  });
+
+  // Your tests...
+});
+```
+
+## Best Practices
+
+1. **Key Management**
+
+   - Use consistent key naming conventions
+   - Consider using key prefixes to avoid collisions
+   - Document key patterns used in your application
+
+2. **Error Handling**
+
+   - Always handle potential Redis connection errors
+   - Implement fallback mechanisms for cache failures
+   - Use try-catch blocks around cache operations
+
+3. **Performance**
+   - Set appropriate TTL values for cached data
+   - Monitor cache hit/miss ratios
+   - Consider implementing cache warming strategies
+
+## Contributing
+
+Feel free to submit issues and enhancement requests!

--- a/src/cache/redis/README.md
+++ b/src/cache/redis/README.md
@@ -8,6 +8,7 @@ This module provides a Redis-based caching solution for NestJS applications. It 
 
 - A configurable Redis cache module
 - A service wrapper for Redis operations
+- Support for Redis Cluster and AWS ElastiCache
 - Mock implementations for testing
 
 ## Directory Structure
@@ -25,6 +26,7 @@ redis/
 - Configurable Redis connection
 - Type-safe cache operations
 - Easy-to-use service interface
+- Redis Cluster support
 - Testing utilities and mocks
 - Integration with NestJS dependency injection
 
@@ -40,6 +42,8 @@ npm install ioredis
 
 ### 1. Import the Module
 
+#### Single Node Mode
+
 ```typescript
 import { Module } from '@nestjs/common';
 import { RedisCacheModule } from './cache/redis/cache.module';
@@ -50,6 +54,35 @@ import { RedisCacheModule } from './cache/redis/cache.module';
       host: 'localhost',
       port: 6379,
       // other Redis options...
+    }),
+  ],
+})
+export class AppModule {}
+```
+
+#### Cluster Mode
+
+> [!WARNING]
+> The `nodes` and `options` keys are not yet integrated!
+
+```typescript
+import { Module } from '@nestjs/common';
+import { RedisCacheModule } from './cache/redis/cache.module';
+
+@Module({
+  imports: [
+    RedisCacheModule.register({
+      clusterMode: true,
+      nodes: [
+        { host: 'redis-node-1', port: 6379 },
+        { host: 'redis-node-2', port: 6379 },
+        { host: 'redis-node-3', port: 6379 },
+      ],
+      options: {
+        scaleReads: 'SLAVE', // Read from replicas
+        maxRedirections: 16,
+        retryDelayOnFailover: 100,
+      },
     }),
   ],
 })
@@ -81,7 +114,7 @@ export class YourService {
 
 ## Configuration Options
 
-The `RedisCacheModule.forRoot()` method accepts standard Redis configuration options:
+The `RedisCacheModule.forRoot()` method accepts standard Redis configuration options plus cluster-specific options:
 
 ```typescript
 interface RedisCacheModuleOptions {
@@ -167,9 +200,16 @@ describe('YourService', () => {
    - Use try-catch blocks around cache operations
 
 3. **Performance**
+
    - Set appropriate TTL values for cached data
    - Monitor cache hit/miss ratios
    - Consider implementing cache warming strategies
+
+4. **Cluster Mode Considerations**
+
+   - Implement proper error handling for node failures
+   - Use appropriate read/write consistency settings
+   - Monitor cluster health and replication status
 
 ## Contributing
 

--- a/src/cache/redis/mocks/redis.cache.service.mock.ts
+++ b/src/cache/redis/mocks/redis.cache.service.mock.ts
@@ -1,0 +1,12 @@
+import { CacheService } from '../redis.cache.service';
+
+const mockRedisService = { getOrThrow: jest.fn() };
+
+export class MockRedisCacheService extends CacheService {
+  constructor() {
+    super(mockRedisService as any);
+  }
+
+  public get = jest.fn();
+  public set = jest.fn();
+}

--- a/src/cache/redis/redis.cache.module.ts
+++ b/src/cache/redis/redis.cache.module.ts
@@ -1,0 +1,118 @@
+import { DynamicModule, Global, Module } from '@nestjs/common';
+import { Cluster, Redis } from 'ioredis';
+import { CacheService } from './redis.cache.service';
+
+interface RedisCacheModuleOptions {
+  protocol: 'redis' | 'rediss';
+  password?: string;
+  host: string;
+  port: number;
+  clusterMode?: boolean;
+  reconnectionDelayMs?: number;
+  reconnectionMaxRetries?: number;
+}
+
+interface RedisCacheModuleAsyncOptions {
+  useFactory: (
+    ...args: any[]
+  ) => Promise<RedisCacheModuleOptions> | RedisCacheModuleOptions;
+  inject?: any[];
+}
+
+export type RedisClient = Redis | Cluster;
+export const REDIS_CLIENT = 'REDIS_CLIENT_TOKEN';
+
+/**
+ * CacheModule
+ *
+ * A simple wrapper for the `RedisModule` or `ClusterModule` instantiation.
+ * Both of those are global by default.
+ */
+@Global()
+@Module({})
+export class RedisCacheModule {
+  /**
+   * Creates a Redis client based on the provided configuration
+   */
+  private static createRedisClient(
+    config: RedisCacheModuleOptions,
+  ): RedisClient {
+    const {
+      clusterMode = false,
+      protocol,
+      password,
+      host,
+      port,
+      reconnectionDelayMs = 5000,
+      reconnectionMaxRetries = 10,
+    } = config;
+
+    const commonOptions = {
+      retryStrategy: (times: number) => {
+        // Retry after `reconnectionDelayMs` milliseconds, with a maximum of `reconnectionMaxRetries` retries
+        if (times < reconnectionMaxRetries) {
+          return reconnectionDelayMs;
+        }
+        // Stop retrying after `reconnectionMaxRetries` attempts
+        return null;
+      },
+    };
+
+    if (clusterMode) {
+      // This is specially tailored for AWS ElastiCache
+      // https://github.com/redis/ioredis?tab=readme-ov-file#special-note-aws-elasticache-clusters-with-tls
+      return new Cluster([{ host, port }], {
+        dnsLookup: (address, callback) => callback(null, address),
+        redisOptions: {
+          password,
+          tls: {},
+          ...commonOptions,
+        },
+      }) as RedisClient;
+    }
+
+    const redisUrl = `${protocol}://:${password}@${host}:${port}`;
+    return new Redis(redisUrl, commonOptions) as RedisClient;
+  }
+
+  /**
+   * Creates a Redis client based on the provided configuration.
+   * Use this for sync configuration (i.e. when the config is available at module load time).
+   */
+  static forRoot(options: RedisCacheModuleOptions): DynamicModule {
+    return {
+      module: RedisCacheModule,
+      providers: [
+        {
+          provide: REDIS_CLIENT,
+          useFactory: () => RedisCacheModule.createRedisClient(options),
+        },
+        CacheService,
+      ],
+      exports: [CacheService, REDIS_CLIENT],
+    };
+  }
+
+  /**
+   * Creates a Redis client based on the provided configuration.
+   * Use this for async configuration (i.e. when the config is not available at module load time).
+   * For example, this is useful when using the `ConfigModule`, and when the config is provided via injection.
+   */
+  static forRootAsync(options: RedisCacheModuleAsyncOptions): DynamicModule {
+    return {
+      module: RedisCacheModule,
+      providers: [
+        {
+          provide: REDIS_CLIENT,
+          useFactory: async (...args: any[]) => {
+            const config = await options.useFactory(...args);
+            return RedisCacheModule.createRedisClient(config);
+          },
+          inject: options.inject || [],
+        },
+        CacheService,
+      ],
+      exports: [CacheService, REDIS_CLIENT],
+    };
+  }
+}

--- a/src/cache/redis/redis.cache.service.ts
+++ b/src/cache/redis/redis.cache.service.ts
@@ -1,0 +1,36 @@
+import type { RedisClient } from './redis.cache.module';
+
+import { Inject, Injectable } from '@nestjs/common';
+import { REDIS_CLIENT } from './redis.cache.module';
+
+@Injectable()
+export class CacheService {
+  constructor(@Inject(REDIS_CLIENT) private readonly _redis: RedisClient) {}
+
+  /**
+   * Gets the Redis client.
+   * @returns {RedisClient} The Redis client.
+   */
+  get client(): RedisClient {
+    return this._redis;
+  }
+
+  /**
+   * Gets the value at the specified key.
+   * @param {string} key - The key to get the value from.
+   * @returns {Promise<string | null>} The result of the get operation.
+   */
+  async get(key: string): Promise<string | null> {
+    return this._redis.get(key);
+  }
+
+  /**
+   * Sets the value at the specified key.
+   * @param {string} key - The key to set the value at.
+   * @param {string | number} value - The value to set at the specified key.
+   * @returns {Promise<void>} The result of the set operation.
+   */
+  async set(key: string, value: string | number): Promise<void> {
+    await this._redis.set(key, value);
+  }
+}


### PR DESCRIPTION
Adds an implementation for the cache module, using Redis behind the scenes.

As discussed with @FloPereira, it could be good if we evolve this into an abstract implementation as well, and have redis be an adapter. But for now, this adds value, so we can start here and then iterate :) 