### PR TITLE
fix: Email imports

### DIFF
--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -4,10 +4,10 @@ import { AuthGuard } from '@nestjs/passport';
 import { AppService } from './app.service';
 import { Html } from './common/decorators/html-content-type';
 import baseConfig from './config/base.config';
-import { EmailType } from './email/sengrid/core/email-type';
-import test2Email from './email/sengrid/emails/test2.email';
 import { TemplateType } from './template/core/template-core.module';
 import testTemplate from './template/templates/test/test.template';
+import { EmailType } from './email/sendgrid/core/email-type';
+import test2Email from './email/sendgrid/emails/test2.email';
 
 @Controller()
 export class AppController {

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -5,7 +5,7 @@ import { AuthModule } from './auth/auth.module';
 import { ConfigModule } from './config/config.module';
 import { MiddlewareModule } from './common/middleware/middleware.module';
 import { TemplateModule } from './template/template.module';
-import { EmailModule } from './email/sengrid/email.module';
+import { EmailModule } from './email/sendgrid/email.module';
 import { SpaceshipModule } from './spaceship/spaceship.module';
 import { PrismaModule } from './prisma/prisma.module';
 


### PR DESCRIPTION
After #6, the imports for sendgrid were messed up because the folder was originally named `sengrid`, missing a `d`.

This PR should fix this, and enable compilation