### PR TITLE
feat: Redis startup check

### DIFF
--- a/src/cache/redis/mocks/redis.cache.service.mock.ts
+++ b/src/cache/redis/mocks/redis.cache.service.mock.ts
@@ -4,7 +4,8 @@ const mockRedisService = { getOrThrow: jest.fn() };
 
 export class MockRedisCacheService extends CacheService {
   constructor() {
-    super(mockRedisService as any);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    super(mockRedisService as any, {} as any);
   }
 
   public get = jest.fn();

--- a/src/cache/redis/redis.cache.module.ts
+++ b/src/cache/redis/redis.cache.module.ts
@@ -1,6 +1,9 @@
-import { DynamicModule, Global, Module } from '@nestjs/common';
+import { DynamicModule, Global, Module, Logger } from '@nestjs/common';
 import { Cluster, Redis, RedisOptions } from 'ioredis';
 import { CacheService } from './redis.cache.service';
+import { adaptLogger, StandardLogger } from './utils/logger';
+
+export const REDIS_LOGGER_TOKEN = 'REDIS_LOGGER_TOKEN';
 
 interface RedisClusterOptions {
   scaleReads?: 'master' | 'slave' | 'all';
@@ -32,6 +35,7 @@ interface BaseRedisCacheModuleOptions {
   port: number;
   reconnectionDelayMs?: number;
   reconnectionMaxRetries?: number;
+  logger?: StandardLogger;
 }
 
 /**
@@ -58,10 +62,13 @@ type RedisCacheModuleOptions =
   | StandaloneRedisCacheModuleOptions
   | ClusterRedisCacheModuleOptions;
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AsyncFactoryFn<T> = (...args: any[]) => Promise<T> | T;
 
 interface BaseAsyncOptions {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   inject?: any[];
+  logger?: StandardLogger;
 }
 
 /**
@@ -159,9 +166,21 @@ export class RedisCacheModule {
   static forRoot(options: StandaloneRedisCacheModuleOptions): DynamicModule; // Overload for standalone mode
   static forRoot(options: ClusterRedisCacheModuleOptions): DynamicModule; // Overload for cluster mode
   static forRoot(options: RedisCacheModuleOptions): DynamicModule {
+    const { logger: providedLogger } = options;
+
     return {
       module: RedisCacheModule,
       providers: [
+        Logger,
+        {
+          provide: REDIS_LOGGER_TOKEN,
+          inject: [Logger],
+          useFactory: (defaultLogger: Logger) => {
+            const logger: StandardLogger =
+              providedLogger ?? adaptLogger(defaultLogger);
+            return logger;
+          },
+        },
         {
           provide: REDIS_CLIENT,
           useFactory: () => RedisCacheModule.createRedisClient(options),
@@ -180,11 +199,24 @@ export class RedisCacheModule {
   static forRootAsync(options: StandaloneAsyncOptions): DynamicModule; // Overload for standalone mode async
   static forRootAsync(options: ClusterAsyncOptions): DynamicModule; // Overload for cluster mode async
   static forRootAsync(options: RedisCacheModuleAsyncOptions): DynamicModule {
+    const { logger: providedLogger } = options;
+
     return {
       module: RedisCacheModule,
       providers: [
+        Logger,
+        {
+          provide: REDIS_LOGGER_TOKEN,
+          inject: [Logger],
+          useFactory: (defaultLogger: Logger) => {
+            const logger: StandardLogger =
+              providedLogger ?? adaptLogger(defaultLogger);
+            return logger;
+          },
+        },
         {
           provide: REDIS_CLIENT,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
           useFactory: async (...args: any[]) => {
             const config = await options.useFactory(...args);
             return RedisCacheModule.createRedisClient(config);

--- a/src/cache/redis/redis.cache.service.ts
+++ b/src/cache/redis/redis.cache.service.ts
@@ -1,11 +1,18 @@
 import type { RedisClient } from './redis.cache.module';
 
 import { Inject, Injectable } from '@nestjs/common';
-import { REDIS_CLIENT } from './redis.cache.module';
+import { REDIS_CLIENT, REDIS_LOGGER_TOKEN } from './redis.cache.module';
+import { StandardLogger } from './utils/logger';
 
 @Injectable()
 export class CacheService {
-  constructor(@Inject(REDIS_CLIENT) private readonly _redis: RedisClient) {}
+  constructor(
+    @Inject(REDIS_CLIENT) private readonly _redis: RedisClient,
+    @Inject(REDIS_LOGGER_TOKEN) private readonly _logger: StandardLogger,
+  ) {
+    // Verify Redis connection immediately on startup
+    this._verifyConnection();
+  }
 
   /**
    * Gets the Redis client.
@@ -49,5 +56,162 @@ export class CacheService {
    */
   async clear(): Promise<void> {
     await this._redis.flushall();
+  }
+
+  /**
+   * Returns all keys that match the pattern.
+   * @param {string} pattern - The pattern to match.
+   * @returns {Promise<string[]>} The result of the keys operation.
+   */
+  async keys(pattern: string): Promise<string[]> {
+    return this._redis.keys(pattern);
+  }
+
+  /**
+   * Prepends one or more values to a list.
+   * @param {string} key - The key of the list.
+   * @param {string | string[]} value - The value(s) to prepend.
+   * @returns {Promise<number>} The length of the list after the push operation.
+   */
+  async lpush(key: string, value: string | string[]): Promise<number> {
+    if (Array.isArray(value)) {
+      return this._redis.lpush(key, ...value);
+    }
+    return this._redis.lpush(key, value);
+  }
+
+  /**
+   * Appends one or more values to a list.
+   * @param {string} key - The key of the list.
+   * @param {string | string[]} value - The value(s) to append.
+   * @returns {Promise<number>} The length of the list after the push operation.
+   */
+  async rpush(key: string, value: string | string[]): Promise<number> {
+    if (Array.isArray(value)) {
+      return this._redis.rpush(key, ...value);
+    }
+    return this._redis.rpush(key, value);
+  }
+
+  /**
+   * Removes and returns the first element of a list.
+   * @param {string} key - The key of the list.
+   * @returns {Promise<string | null>} The popped element.
+   */
+  async lpop(key: string): Promise<string | null> {
+    return this._redis.lpop(key);
+  }
+
+  /**
+   * Removes and returns the last element of a list.
+   * @param {string} key - The key of the list.
+   * @returns {Promise<string | null>} The popped element.
+   */
+  async rpop(key: string): Promise<string | null> {
+    return this._redis.rpop(key);
+  }
+
+  /**
+   * Returns a range of elements from a list.
+   * @param {string} key - The key of the list.
+   * @param {number} start - The start index.
+   * @param {number} stop - The stop index.
+   * @returns {Promise<string[]>} The range of elements.
+   */
+  async lrange(key: string, start: number, stop: number): Promise<string[]> {
+    return this._redis.lrange(key, start, stop);
+  }
+
+  /**
+   * Returns the length of a list.
+   * @param {string} key - The key of the list.
+   * @returns {Promise<number>} The length of the list.
+   */
+  async llen(key: string): Promise<number> {
+    return this._redis.llen(key);
+  }
+
+  /**
+   * Removes elements from a list.
+   * @param {string} key - The key of the list.
+   * @param {number} count - Number of occurrences to remove.
+   * @param {string} value - The value to remove.
+   * @returns {Promise<number>} The number of removed elements.
+   */
+  async lrem(key: string, count: number, value: string): Promise<number> {
+    return this._redis.lrem(key, count, value);
+  }
+
+  /**
+   * Verifies Redis connection with timeout and fails fast if unavailable
+   * @private
+   */
+  private async _verifyConnection(): Promise<void> {
+    const TIMEOUT_MS = 5000; // 5 second timeout
+    const testKey = `redis-startup-test-${Date.now()}`;
+    const testValue = 'connection-test';
+
+    try {
+      const connectionTest = Promise.race([
+        this._testRedisOperations(testKey, testValue),
+        this._createTimeoutPromise(TIMEOUT_MS),
+      ]);
+      await connectionTest;
+    } catch (error) {
+      this._logger.error({
+        message: '❌ Redis connection failed:',
+        data: { error: error.message },
+      });
+
+      this._logger.error({
+        message: '🚨 STOPPING APPLICATION - Redis is required for operation',
+      });
+
+      process.exit(1); // Hard stop the application
+    }
+  }
+
+  /**
+   * Test Redis read/write operations
+   * @param {string} testKey - The key to test the read/write operations on.
+   * @param {string} testValue - The value to test the read/write operations on.
+   * @private
+   */
+  private async _testRedisOperations(
+    testKey: string,
+    testValue: string,
+  ): Promise<void> {
+    const startTime = Date.now();
+
+    // Test write
+    await this._redis.set(testKey, testValue);
+
+    // Test read
+    const retrievedValue = await this._redis.get(testKey);
+
+    if (retrievedValue !== testValue) {
+      throw new Error(
+        `Redis read/write test failed. Expected: ${testValue}, Got: ${retrievedValue}`,
+      );
+    }
+
+    // Clean up
+    await this._redis.del(testKey);
+
+    const responseTime = Date.now() - startTime;
+    console.log(`✅ Redis operations completed in ${responseTime}ms`);
+  }
+
+  /**
+   * Create a timeout promise that rejects after specified milliseconds
+   * @param {number} timeoutMs - The number of milliseconds to wait before rejecting the promise.
+   * @private
+   */
+  private _createTimeoutPromise(timeoutMs: number): Promise<never> {
+    return new Promise((_, reject) => {
+      setTimeout(() => {
+        reject(new Error(`Redis connection timeout after ${timeoutMs}ms`));
+      }, timeoutMs);
+    });
   }
 }

--- a/src/cache/redis/utils/logger.ts
+++ b/src/cache/redis/utils/logger.ts
@@ -1,0 +1,42 @@
+import type { Logger } from "@nestjs/common";
+
+export interface LoggerInput {
+  message: string;
+  data?: Record<string, unknown>;
+}
+
+export interface StandardLogger {
+  setContext: (context: string) => void;
+  info: (input: LoggerInput) => void;
+  error: (input: LoggerInput) => void;
+  warn: (input: LoggerInput) => void;
+  debug: (input: LoggerInput) => void;
+}
+
+/**
+ * Function used to format the log message.
+ * @param {LoggerInput} input - The logger input.
+ * @returns {string} The formatted log message.
+ */
+function formatLogMessage(input: LoggerInput): string {
+  if (!input.data || Object.keys(input.data).length === 0) {
+    return input.message;
+  }
+  return `${input.message} - ${JSON.stringify(input.data)}`;
+}
+
+/**
+ * Function used to adapt the logger to the StandardLogger interface.
+ * @param {Logger} logger - The logger to adapt.
+ * @returns {StandardLogger} The adapted logger.
+ */
+export function adaptLogger(logger: Logger): StandardLogger {
+  return {
+    // eslint-disable-next-line ts/no-explicit-any
+    setContext: (logger as any).setContext ?? (() => {}),
+    info: (input: LoggerInput) => logger.log(formatLogMessage(input)),
+    error: (input: LoggerInput) => logger.error(formatLogMessage(input)),
+    warn: (input: LoggerInput) => logger.warn(formatLogMessage(input)),
+    debug: (input: LoggerInput) => logger.debug(formatLogMessage(input)),
+  };
+}


### PR DESCRIPTION
If you connect to a cluster instance as if it was a single instance, the application freezes when sending requests to Redis.

This is a silent error: no logs are emitted.

So we decided to do an initial test on startup. This ensures configuration is correct, and has a `Promise.race` to detect timeouts.