### PR TITLE
chore: pin Node.js version to 24.15.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts-alpine
+FROM node:24.15.0
 # RUN as root
 RUN apk add dumb-init
 RUN corepack enable && corepack prepare pnpm@10.15.1 --activate

--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -1,4 +1,4 @@
-image: node:lts-alpine
+image: node:24.15.0
 
 definitions:
   caches:
@@ -17,7 +17,7 @@ definitions:
         artifacts:
           - dist/**
     - step: &build_publish_and_deploy
-        image: node:alpine
+        image: node:24.15.0
         name: Backend build/publish docker to ECR, deploy to ECS, and lambda build/deploy.
         services:
           # Enable Docker for your repository

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "author": "",
   "private": true,
   "license": "UNLICENSED",
+  "engines": {
+    "node": "^24.0.0"
+  },
   "packageManager": "pnpm@10.15.1",
   "scripts": {
     "prebuild": "rimraf dist",


### PR DESCRIPTION
  ## Summary

  - Replaces `node:lts-alpine` with `node:24.15.0` in `Dockerfile` and `bitbucket-pipelines.yml` for reproducible builds
  - Adds `engines: { "node": "^24.0.0" }` to `package.json` to enforce Node 24 for local development

  ## Why

  Pinning to an explicit version instead of `lts` avoids unexpected behavior when the LTS tag moves to a new major. Docker and CI now use the same image tag, reducing
  environment drift.